### PR TITLE
feat(server): get data from statuscake to metrics

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "env": {
-      "node": true
+      "node": true,
+      "jest": true
     },
     "extends": [
         "@m6web"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "start": "node src/index.js",
-    "lint": "eslint src/*.js",
+    "lint": "eslint src/*",
     "test": "jest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "axios": "0.19.0",
     "config": "3.2.4",
     "debug": "4.1.1",
-    "express": "4.17.1"
+    "express": "4.17.1",
+    "prom-client": "11.5.3"
   },
   "devDependencies": {
     "@m6web/eslint-config": "3.3.0",

--- a/src/___tests__/server.test.js
+++ b/src/___tests__/server.test.js
@@ -11,8 +11,8 @@ jest.mock('../statuscakedata', () => ({
   getData: jest.fn().mockReturnValue('fake-data')
 }))
 
-test('server should return ', async () => {
-    const response = await request(app).get('/').expect(200)
-    //expect(response.text).toEqual('fake-data')
-    expect(Storage.getData).toBeCalledTimes(1)
-});
+// test('server should return ', async () => {
+//     const response = await request(app).get('/').expect(200)
+//     expect(response.text).toEqual('fake-data')
+//     expect(Storage.getData).toBeCalledTimes(1)
+// });

--- a/src/___tests__/server.test.js
+++ b/src/___tests__/server.test.js
@@ -1,18 +1,21 @@
-const request = require("supertest");
-const Storage = require('../statuscakedata');
+const request = require('supertest');
 const app = require('../server');
 
-jest.mock('config', () => ({statuscake: {
-  "route": "/",
-  "listener": 3000,
-}}))
+jest.mock('prom-client', () => ({
+  register: {
+    contentType: 'fakeContentType',
+    metrics: jest.fn(() => 'test-value'),
+  },
+}));
 
-jest.mock('../statuscakedata', () => ({
-  getData: jest.fn().mockReturnValue('fake-data')
-}))
+describe('Server', () => {
+  test('should respond prom-client metrics values', async () => {
+    const response = await request(app).get('/metrics').expect(200);
+    expect(response.text).toEqual('test-value');
+  });
 
-test('server should return ', async () => {
-    const response = await request(app).get('/metrics').expect(200)
-    expect(response.text).toEqual('fake-data')
-    expect(Storage.getData).toBeCalledTimes(1)
+  test('should respond with Header Content-type based on prom-client', async () => {
+    const response = await request(app).get('/metrics').expect(200);
+    expect(response.headers['content-type']).toEqual('fakeContentType');
+  });
 });

--- a/src/___tests__/server.test.js
+++ b/src/___tests__/server.test.js
@@ -2,7 +2,7 @@ const request = require("supertest");
 const Storage = require('../statuscakedata');
 const app = require('../server');
 
-jest.mock('config', () => ({ statuscake: {
+jest.mock('config', () => ({statuscake: {
   "route": "/",
   "listener": 3000,
 }}))
@@ -13,6 +13,6 @@ jest.mock('../statuscakedata', () => ({
 
 test('server should return ', async () => {
     const response = await request(app).get('/').expect(200)
-    expect(response.text).toEqual('fake-data')
+    //expect(response.text).toEqual('fake-data')
     expect(Storage.getData).toBeCalledTimes(1)
 });

--- a/src/___tests__/server.test.js
+++ b/src/___tests__/server.test.js
@@ -11,8 +11,8 @@ jest.mock('../statuscakedata', () => ({
   getData: jest.fn().mockReturnValue('fake-data')
 }))
 
-// test('server should return ', async () => {
-//     const response = await request(app).get('/').expect(200)
-//     expect(response.text).toEqual('fake-data')
-//     expect(Storage.getData).toBeCalledTimes(1)
-// });
+test('server should return ', async () => {
+    const response = await request(app).get('/').expect(200)
+    expect(response.text).toEqual('fake-data')
+    expect(Storage.getData).toBeCalledTimes(1)
+});

--- a/src/___tests__/server.test.js
+++ b/src/___tests__/server.test.js
@@ -12,7 +12,7 @@ jest.mock('../statuscakedata', () => ({
 }))
 
 test('server should return ', async () => {
-    const response = await request(app).get('/').expect(200)
+    const response = await request(app).get('/metrics').expect(200)
     expect(response.text).toEqual('fake-data')
     expect(Storage.getData).toBeCalledTimes(1)
 });

--- a/src/___tests__/statuscake.test.js
+++ b/src/___tests__/statuscake.test.js
@@ -16,24 +16,24 @@ jest.mock('../statuscakedata', () => ({
 }))
 
 test('fetchStatuCakeData call axios', async () => {
-    axios.get.mockResolvedValue({ data: { data: [{
-      ID: 49216,
-      Title: '6play.fr - Programme NCIS - Mobile',
-      URL: 'http://www.6play.fr/n-c-i-s-p_843',
-      Location: 'FR1.PAGESPEED.STATUSCAKE.NET',
-      Location_ISO: 'FR',
-      ContactGroups: [],
-      LatestStats: { Loadtime_ms: 5374, Filesize_kb: 4080.815, Requests: 47 }
-    },
-    {
-      ID: 49217,
-      Title: '6play.fr - Programme Z NCIS - Mobile',
-      URL: 'http://www.6play.fr/n-c-i-s-p_843',
-      Location: 'FR1.PAGESPEED.STATUSCAKE.NET',
-      Location_ISO: 'FR',
-      ContactGroups: [],
-      LatestStats: { Loadtime_ms: 4394, Filesize_kb: 3514.8, Requests: 26 }
-    }] }});
+  axios.get.mockResolvedValue({ data: { data: [{
+    ID: 49216,
+    Title: '6play.fr - Programme NCIS - Mobile',
+    URL: 'http://www.6play.fr/n-c-i-s-p_843',
+    Location: 'FR1.PAGESPEED.STATUSCAKE.NET',
+    Location_ISO: 'FR',
+    ContactGroups: [],
+    LatestStats: { Loadtime_ms: 5374, Filesize_kb: 4080.815, Requests: 47 }
+  },
+  {
+    ID: 49217,
+    Title: '6play.fr - Programme Z NCIS - Mobile',
+    URL: 'http://www.6play.fr/n-c-i-s-p_843',
+    Location: 'FR1.PAGESPEED.STATUSCAKE.NET',
+    Location_ISO: 'FR',
+    ContactGroups: [],
+    LatestStats: { Loadtime_ms: 4394, Filesize_kb: 3514.8, Requests: 26 }
+  }] }})};
 
     await fetchStatuCakeData();
     expect(axios.get).toBeCalledWith("https://example.com/API/Pagespeed/?API=api-key&Username=user");

--- a/src/___tests__/statuscake.test.js
+++ b/src/___tests__/statuscake.test.js
@@ -1,43 +1,48 @@
-const fetchStatuCakeData = require('../statuscake');
-const StatutCakeData = require('../statuscakedata');
 const axios = require('axios');
-const config = require('config');
+const fetchStatuCakeData = require('../statuscake');
 const Storage = require('../statuscakedata');
 
 jest.mock('axios');
-jest.mock('config', () => ({ statuscake: {
-  "apikey": "api-key",
-  "username": "user",
-  "baseUrl": "https://example.com/API/Pagespeed/",
-}}))
+jest.mock('config', () => ({
+  statuscake: {
+    apikey: 'api-key',
+    username: 'user',
+    baseUrl: 'https://example.com/API/Pagespeed/',
+  },
+}));
 
 jest.mock('../statuscakedata', () => ({
-  setData: jest.fn()
-}))
+  setData: jest.fn(),
+}));
+
 
 test('fetchStatuCakeData call axios', async () => {
-  axios.get.mockResolvedValue({ data: { data: [{
-    ID: 49216,
-    Title: '6play.fr - Programme NCIS - Mobile',
-    URL: 'http://www.6play.fr/n-c-i-s-p_843',
-    Location: 'FR1.PAGESPEED.STATUSCAKE.NET',
-    Location_ISO: 'FR',
-    ContactGroups: [],
-    LatestStats: { Loadtime_ms: 5374, Filesize_kb: 4080.815, Requests: 47 }
-  },
-  {
-    ID: 49217,
-    Title: '6play.fr - Programme Z NCIS - Mobile',
-    URL: 'http://www.6play.fr/n-c-i-s-p_843',
-    Location: 'FR1.PAGESPEED.STATUSCAKE.NET',
-    Location_ISO: 'FR',
-    ContactGroups: [],
-    LatestStats: { Loadtime_ms: 4394, Filesize_kb: 3514.8, Requests: 26 }
-  }] }})};
+  axios.get.mockResolvedValue({
+    data: {
+      data: [{
+        ID: 49216,
+        Title: '6play.fr - Programme NCIS - Mobile',
+        URL: 'http://www.6play.fr/n-c-i-s-p_843',
+        Location: 'FR1.PAGESPEED.STATUSCAKE.NET',
+        Location_ISO: 'FR',
+        ContactGroups: [],
+        LatestStats: { Loadtime_ms: 5374, Filesize_kb: 4080.815, Requests: 47 },
+      },
+      {
+        ID: 49217,
+        Title: '6play.fr - Programme Z NCIS - Mobile',
+        URL: 'http://www.6play.fr/n-c-i-s-p_843',
+        Location: 'FR1.PAGESPEED.STATUSCAKE.NET',
+        Location_ISO: 'FR',
+        ContactGroups: [],
+        LatestStats: { Loadtime_ms: 4394, Filesize_kb: 3514.8, Requests: 26 },
+      }],
+    },
+  });
 
-    await fetchStatuCakeData();
-    expect(axios.get).toBeCalledWith("https://example.com/API/Pagespeed/?API=api-key&Username=user");
-    expect(Storage.setData).toBeCalledTimes(2)
+  await fetchStatuCakeData(Storage);
+  expect(axios.get).toBeCalledWith('https://example.com/API/Pagespeed/?API=api-key&Username=user');
+  expect(Storage.setData).toBeCalledTimes(1);
 });
 
 
@@ -46,6 +51,5 @@ test('fetchStatuCakeData should have an error', async () => {
 
   await fetchStatuCakeData();
 
-  expect(axios.get).toBeCalledWith("https://example.com/API/Pagespeed/?API=api-key&Username=user");
-  
+  expect(axios.get).toBeCalledWith('https://example.com/API/Pagespeed/?API=api-key&Username=user');
 });

--- a/src/___tests__/statuscake.test.js
+++ b/src/___tests__/statuscake.test.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 const fetchStatuCakeData = require('../statuscake');
-const Storage = require('../statuscakedata');
+const storage = require('../statuscakedata');
 
 jest.mock('axios');
 jest.mock('config', () => ({
@@ -40,9 +40,9 @@ test('fetchStatuCakeData call axios', async () => {
     },
   });
 
-  await fetchStatuCakeData(Storage);
+  await fetchStatuCakeData(storage);
   expect(axios.get).toBeCalledWith('https://example.com/API/Pagespeed/?API=api-key&Username=user');
-  expect(Storage.setData).toBeCalledTimes(1);
+  expect(storage.setData).toBeCalledTimes(1);
 });
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const client = require('prom-client');
 const config = require('config');
 const fetchStatuCakeData = require('./statuscake');
 const server = require('./server');
-const Storage = require('./statuscakedata');
+const storage = require('./statuscakedata');
 
 const regex = /\s?([-])\s?/;
 
@@ -25,11 +25,10 @@ const requestGauge = new client.Gauge({
 });
 
 setInterval(() => {
-  const date = (100, Date.now());
-  const data = Storage.getData();
+  const date = (Date.now());
+  const data = storage.getData();
   if (data.length > 0) {
-    const startsWithPrometheus = data.filter(d => String(d.Title).startsWith('[prometheus]'));
-    startsWithPrometheus.forEach((myItem) => {
+    data.forEach((myItem) => {
       const parsedTitle = getTagsFromTitle(myItem.Title);
       const labels = {
         customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
@@ -40,8 +39,8 @@ setInterval(() => {
       setter(requestGauge, myItem.LatestStats.Requests);
     });
   }
-}, 100);
+});
 
-this.interval = setInterval(() => fetchStatuCakeData(Storage), config.statuscake.interval);
+this.interval = setInterval(() => fetchStatuCakeData(storage), config.statuscake.interval);
 
 server.listen(config.statuscake.listener);

--- a/src/index.js
+++ b/src/index.js
@@ -28,15 +28,18 @@ setInterval(() => {
   const date = (100, Date.now());
   const data = Storage.getData();
   if (data.length > 0) {
-    data.forEach((myItem) => {
+    const startsWithPrometheus = data.filter(d => String(d.Title).startsWith('[prometheus]'));
+    startsWithPrometheus.forEach((myItem) => {
       const parsedTitle = getTagsFromTitle(myItem.Title);
       const labels = {
         customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
       };
-      const setter = gauge => gauge.set(labels, myItem.LatestStats.loadTimeMS, date);
-      setter(g);
-      setter(h);
-      setter(i);
+      const setterLoadTime = gauge => gauge.set(labels, myItem.LatestStats.loadTimeMS, date);
+      setterLoadTime(g);
+      const setterSize = gauge => gauge.set(labels, myItem.LatestStats.fileSizeKB, date);
+      setterSize(h);
+      const setterRequest = gauge => gauge.set(labels, myItem.LatestStats.Requests, date);
+      setterRequest(i);
     });
   }
 }, 100);

--- a/src/index.js
+++ b/src/index.js
@@ -34,12 +34,10 @@ setInterval(() => {
       const labels = {
         customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
       };
-      const setterLoadTime = gauge => gauge.set(labels, myItem.LatestStats.loadTimeMS, date);
-      setterLoadTime(g);
-      const setterSize = gauge => gauge.set(labels, myItem.LatestStats.fileSizeKB, date);
-      setterSize(h);
-      const setterRequest = gauge => gauge.set(labels, myItem.LatestStats.Requests, date);
-      setterRequest(i);
+      const setter = (gauge, value) => gauge.set(labels, value, date);
+      setter(g, myItem.LatestStats.loadTimeMS);
+      setter(h, myItem.LatestStats.fileSizeKB);
+      setter(i, myItem.LatestStats.Requests);
     });
   }
 }, 100);

--- a/src/index.js
+++ b/src/index.js
@@ -9,18 +9,18 @@ const regex = /\s?([-])\s?/;
 const getTagsFromTitle = Title => Title.split(regex);
 
 const g = new client.Gauge({
-  name: 'metric_loadtime',
-  help: 'metric_help',
+  name: 'frontend_pagespeed_loadtime_seconds',
+  help: 'Loadtime of your page',
   labelNames: ['customer', 'service', 'device', 'version'],
 });
 const h = new client.Gauge({
-  name: 'metric_filesize',
-  help: 'metric_help',
+  name: 'frontend_pagespeed_filesize_bytes',
+  help: 'Filesize of your page',
   labelNames: ['customer', 'service', 'device', 'version'],
 });
 const i = new client.Gauge({
-  name: 'metric_request',
-  help: 'metric_help',
+  name: 'frontend_pagespeed_request_count',
+  help: 'Number of request',
   labelNames: ['customer', 'service', 'device', 'version'],
 });
 
@@ -30,15 +30,13 @@ setInterval(() => {
   if (data.length > 0) {
     data.forEach((myItem) => {
       const parsedTitle = getTagsFromTitle(myItem.Title);
-      g.set({
+      const labels = {
         customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
-      }, myItem.LatestStats.loadTimeMS, date);
-      h.set({
-        customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
-      }, myItem.LatestStats.fileSizeKB, date);
-      i.set({
-        customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
-      }, myItem.LatestStats.Requests, date);
+      };
+      const setter = gauge => gauge.set(labels, myItem.LatestStats.loadTimeMS, date);
+      setter(g);
+      setter(h);
+      setter(i);
     });
   }
 }, 100);

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 const config = require('config');
 const fetchStatuCakeData = require('./statuscake');
 const server = require('./server');
+const Storage = require('./statuscakedata');
 
-this.interval = setInterval(fetchStatuCakeData, config.statuscake.interval);
+this.interval = setInterval(() => fetchStatuCakeData(Storage), config.statuscake.interval);
 
-server.listen(config.statuscake.listener);
+server(Storage).listen(config.statuscake.listener);

--- a/src/index.js
+++ b/src/index.js
@@ -8,17 +8,17 @@ const regex = /\s?([-])\s?/;
 
 const getTagsFromTitle = Title => Title.split(regex);
 
-const g = new client.Gauge({
+const loadtimeGauge = new client.Gauge({
   name: 'frontend_pagespeed_loadtime_seconds',
   help: 'Loadtime of your page',
   labelNames: ['customer', 'service', 'device', 'version'],
 });
-const h = new client.Gauge({
+const filesizeGauge = new client.Gauge({
   name: 'frontend_pagespeed_filesize_bytes',
   help: 'Filesize of your page',
   labelNames: ['customer', 'service', 'device', 'version'],
 });
-const i = new client.Gauge({
+const requestGauge = new client.Gauge({
   name: 'frontend_pagespeed_request_count',
   help: 'Number of request',
   labelNames: ['customer', 'service', 'device', 'version'],
@@ -35,9 +35,9 @@ setInterval(() => {
         customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
       };
       const setter = (gauge, value) => gauge.set(labels, value, date);
-      setter(g, myItem.LatestStats.loadTimeMS);
-      setter(h, myItem.LatestStats.fileSizeKB);
-      setter(i, myItem.LatestStats.Requests);
+      setter(loadtimeGauge, myItem.LatestStats.loadTimeMS);
+      setter(filesizeGauge, myItem.LatestStats.fileSizeKB);
+      setter(requestGauge, myItem.LatestStats.Requests);
     });
   }
 }, 100);

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,48 @@
+const client = require('prom-client');
 const config = require('config');
 const fetchStatuCakeData = require('./statuscake');
 const server = require('./server');
 const Storage = require('./statuscakedata');
 
+const regex = /\s?([-])\s?/;
+
+const getTagsFromTitle = Title => Title.split(regex);
+
+const g = new client.Gauge({
+  name: 'metric_loadtime',
+  help: 'metric_help',
+  labelNames: ['customer', 'service', 'device', 'version'],
+});
+const h = new client.Gauge({
+  name: 'metric_filesize',
+  help: 'metric_help',
+  labelNames: ['customer', 'service', 'device', 'version'],
+});
+const i = new client.Gauge({
+  name: 'metric_request',
+  help: 'metric_help',
+  labelNames: ['customer', 'service', 'device', 'version'],
+});
+
+setInterval(() => {
+  const date = (100, Date.now());
+  const data = Storage.getData();
+  if (data.length > 0) {
+    data.forEach((myItem) => {
+      const parsedTitle = getTagsFromTitle(myItem.Title);
+      g.set({
+        customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
+      }, myItem.LatestStats.loadTimeMS, date);
+      h.set({
+        customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
+      }, myItem.LatestStats.fileSizeKB, date);
+      i.set({
+        customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
+      }, myItem.LatestStats.Requests, date);
+    });
+  }
+}, 100);
+
 this.interval = setInterval(() => fetchStatuCakeData(Storage), config.statuscake.interval);
 
-server(Storage).listen(config.statuscake.listener);
+server.listen(config.statuscake.listener);

--- a/src/server.js
+++ b/src/server.js
@@ -1,13 +1,59 @@
+const client = require('prom-client');
+
 const express = require('express');
-const config = require('config');
-const Storage = require('./statuscakedata');
 
-const app = express();
+const regex = /\s?([-])\s?/;
 
-const { route } = config.statuscake;
+const server = express();
+const { register } = client;
+const getTagsFromTitle = Title => Title.split(regex);
 
-app.get(route, (request, response) => {
-  response.send(Storage.getData());
+let Storage = null;
+
+const g = new client.Gauge({
+  name: 'metric_loadtime',
+  help: 'metric_help',
+  labelNames: ['customer', 'service', 'device', 'version'],
+});
+const h = new client.Gauge({
+  name: 'metric_filesize',
+  help: 'metric_help',
+  labelNames: ['customer', 'service', 'device', 'version'],
+});
+const i = new client.Gauge({
+  name: 'metric_request',
+  help: 'metric_help',
+  labelNames: ['customer', 'service', 'device', 'version'],
 });
 
-module.exports = app;
+setInterval(() => {
+  const date = (100, Date.now());
+  const data = Storage.getData();
+  if (data.length > 0) {
+    data.forEach((myItem) => {
+      const parsedTitle = getTagsFromTitle(myItem.Title);
+      g.set({
+        customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
+      }, myItem.LatestStats.loadTimeMS, date);
+      h.set({
+        customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
+      }, myItem.LatestStats.fileSizeKB, date);
+      i.set({
+        customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
+      }, myItem.LatestStats.Requests, date);
+    });
+  }
+}, 100);
+
+server.get('/metrics', (req, res) => {
+  res.set('Content-Type', register.contentType);
+  res.end(register.metrics());
+});
+
+const init = (commonStorage) => {
+  Storage = commonStorage;
+
+  return server;
+};
+
+module.exports = init;

--- a/src/server.js
+++ b/src/server.js
@@ -1,59 +1,12 @@
 const client = require('prom-client');
-
 const express = require('express');
-
-const regex = /\s?([-])\s?/;
 
 const server = express();
 const { register } = client;
-const getTagsFromTitle = Title => Title.split(regex);
-
-let Storage = null;
-
-const g = new client.Gauge({
-  name: 'metric_loadtime',
-  help: 'metric_help',
-  labelNames: ['customer', 'service', 'device', 'version'],
-});
-const h = new client.Gauge({
-  name: 'metric_filesize',
-  help: 'metric_help',
-  labelNames: ['customer', 'service', 'device', 'version'],
-});
-const i = new client.Gauge({
-  name: 'metric_request',
-  help: 'metric_help',
-  labelNames: ['customer', 'service', 'device', 'version'],
-});
-
-setInterval(() => {
-  const date = (100, Date.now());
-  const data = Storage.getData();
-  if (data.length > 0) {
-    data.forEach((myItem) => {
-      const parsedTitle = getTagsFromTitle(myItem.Title);
-      g.set({
-        customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
-      }, myItem.LatestStats.loadTimeMS, date);
-      h.set({
-        customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
-      }, myItem.LatestStats.fileSizeKB, date);
-      i.set({
-        customer: parsedTitle[0], service: parsedTitle[2], device: parsedTitle[4], version: parsedTitle[6],
-      }, myItem.LatestStats.Requests, date);
-    });
-  }
-}, 100);
 
 server.get('/metrics', (req, res) => {
   res.set('Content-Type', register.contentType);
   res.end(register.metrics());
 });
 
-const init = (commonStorage) => {
-  Storage = commonStorage;
-
-  return server;
-};
-
-module.exports = init;
+module.exports = server;

--- a/src/statuscake.js
+++ b/src/statuscake.js
@@ -31,8 +31,7 @@ const fetchStatuCakeData = Storage => axios.get(STATUS_CAKE_BASE_URL)
 
       return myNewItem;
     });
-   
-    console.log(urlsFormated);
+
     Storage.setData(urlsFormated);
   }).catch((error) => {
     logError('axios can not access to the URL', error);

--- a/src/statuscake.js
+++ b/src/statuscake.js
@@ -6,9 +6,9 @@ const config = require('config');
 const { username, apikey, baseUrl } = config.statuscake;
 const STATUS_CAKE_BASE_URL = `${baseUrl}?API=${apikey}&Username=${username}`;
 
-const fetchStatuCakeData = Storage => axios.get(STATUS_CAKE_BASE_URL)
+const fetchStatuCakeData = storage => axios.get(STATUS_CAKE_BASE_URL)
   .then(({ data: { data: urls } }) => {
-    const urlsFormated = urls.map((item) => {
+    const urlsFormated = urls.filter(item => String(item.Title).startsWith('[prometheus]')).map((item) => {
       const {
         URL,
         Title,
@@ -32,7 +32,7 @@ const fetchStatuCakeData = Storage => axios.get(STATUS_CAKE_BASE_URL)
       return myNewItem;
     });
 
-    Storage.setData(urlsFormated);
+    storage.setData(urlsFormated);
   }).catch((error) => {
     logError('axios can not access to the URL', error);
   });

--- a/src/statuscake.js
+++ b/src/statuscake.js
@@ -31,6 +31,8 @@ const fetchStatuCakeData = Storage => axios.get(STATUS_CAKE_BASE_URL)
 
       return myNewItem;
     });
+   
+    console.log(urlsFormated);
     Storage.setData(urlsFormated);
   }).catch((error) => {
     logError('axios can not access to the URL', error);

--- a/src/statuscake.js
+++ b/src/statuscake.js
@@ -2,14 +2,13 @@ const axios = require('axios');
 const debug = require('debug')('statuscake');
 const logError = require('debug')('error');
 const config = require('config');
-const Storage = require('./statuscakedata');
 
 const { username, apikey, baseUrl } = config.statuscake;
 const STATUS_CAKE_BASE_URL = `${baseUrl}?API=${apikey}&Username=${username}`;
 
-const fetchStatuCakeData = () => axios.get(STATUS_CAKE_BASE_URL)
+const fetchStatuCakeData = Storage => axios.get(STATUS_CAKE_BASE_URL)
   .then(({ data: { data: urls } }) => {
-    urls.forEach((item) => {
+    const urlsFormated = urls.map((item) => {
       const {
         URL,
         Title,
@@ -19,10 +18,20 @@ const fetchStatuCakeData = () => axios.get(STATUS_CAKE_BASE_URL)
           Requests,
         },
       } = item;
-
       debug(URL, Title, loadTimeMS, fileSizeKB, Requests);
-      Storage.setData(urls);
+      const myNewItem = {
+        URL,
+        Title,
+        LatestStats: {
+          loadTimeMS,
+          fileSizeKB,
+          Requests,
+        },
+      };
+
+      return myNewItem;
     });
+    Storage.setData(urlsFormated);
   }).catch((error) => {
     logError('axios can not access to the URL', error);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,6 +652,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bintrees@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
+  integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
+
 body-parser@1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
@@ -3525,6 +3530,13 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+prom-client@11.5.3:
+  version "11.5.3"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-11.5.3.tgz#5fedfce1083bac6c2b223738e966d0e1643756f8"
+  integrity sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==
+  dependencies:
+    tdigest "^0.1.1"
+
 prompts@^2.0.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.2.1.tgz#f901dd2a2dfee080359c0e20059b24188d75ad35"
@@ -4277,6 +4289,13 @@ tar@^4:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
+
+tdigest@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
+  integrity sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=
+  dependencies:
+    bintrees "1.0.1"
 
 test-exclude@^5.2.3:
   version "5.2.3"


### PR DESCRIPTION
In this update : 

- You can now get **data** from StatusCake and expose those on route **metrics** 📍 . 

- We use **labels** to tag those data 🏷 .

- You got a **Gauge** and a **date** attached for each data 🕙 .

- You can **filter** your data 🗄  

Screenshot of `/metrics` route :
![Capture d’écran 2019-11-26 à 17 23 37](https://user-images.githubusercontent.com/45287046/69652273-b0b19b80-1071-11ea-8160-39bc620b9bfa.png)
